### PR TITLE
TOPS reader/converter, Planck integral and fast interpolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ the consistency of conversions made with `opac-convert`.
 * hedp (https://github.com/luli/hedp)
 * interpolation (optional for fast interpolation)
 * numba (optional for fast planck integral calculation)
+* beautifulsoup4 (optional for `tops_html2txt`)
 
 They can be installed as follows:
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 Python package for manipulating Equation of State (EoS) and Opacity data.
 
 Opacplot2 includes command-line tools to make EoS tables of various formats
-available to FLASH. `opac-convert` converts EoS/opacity tables like SESAME and
-Propaceos into a FLASH-readable IONMIX (.cn4) format. `opac-error` generates plots comparing the
+available to FLASH. `opac-convert` converts EoS/opacity tables like SESAME,
+Propaceos and TOPS into a FLASH-readable IONMIX (.cn4) format. `opac-error` generates plots comparing the
 contents of two EoS tables for the same material. It is particularly useful for checking
 the consistency of conversions made with `opac-convert`.
 
@@ -18,10 +18,14 @@ the consistency of conversions made with `opac-convert`.
 | SESAME |:heavy_check_mark:|| :heavy_check_mark: | :heavy_check_mark: | 
 | MULTI&#8224; ||:heavy_check_mark:| :heavy_check_mark: | |
 | Propaceos* |:heavy_check_mark:|| :heavy_check_mark: | :heavy_check_mark:  | 
+| TOPS&#8225; |:heavy_check_mark:|:heavy_check_mark:| :heavy_check_mark: || 
+
 
 *<sub>The Propaceos reader is only distributed with a Propaceos license.<sub>
 
 &#8224;<sub>Only opacity parsers are available for MULTI.<sub>
+
+&#8225;<sub>Only average free electron number and average square free electron number in EoS<sub>
 
 ### Dependencies
 
@@ -94,6 +98,7 @@ Supported input file formats:
 * Propaceos (not distributed)
 * SESAME (.ses)
 * MULTI (.opp, .opr, .opz, .eps)
+* TOPS (.html, .tops)
 
 The only supported output format is IONMIX.
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ the consistency of conversions made with `opac-convert`.
 * scipy
 * periodictable
 * hedp (https://github.com/luli/hedp)
+* interpolation (optional for fast interpolation)
+* numba (optional for fast planck integral calculation)
 
 They can be installed as follows:
 

--- a/opacplot2/__init__.py
+++ b/opacplot2/__init__.py
@@ -16,6 +16,7 @@ from .opg_multi     import *
 from .opg_qeos      import *
 from .opg_sesame    import *
 from .opg_tabop     import *
+from .opg_tops      import *
 
 # plotting
 from .opac_plotter  import *

--- a/opacplot2/opg_tops.py
+++ b/opacplot2/opg_tops.py
@@ -44,7 +44,7 @@ class OpgTOPS():
         ----------
         fname : str
             Filename of the .tops or .html file
-        epmax : {'log', 'lin', 'auto'} or float, optional
+        ep_max : {'log', 'lin', 'auto'} or float, optional
             The upper bound of photon energy (keV) in the last photon group, by
             default 'auto'
             - 'log': use logarithmic extrapolation to calculate `epmax`

--- a/opacplot2/opg_tops.py
+++ b/opacplot2/opg_tops.py
@@ -242,5 +242,54 @@ class OpgTOPS():
                             self.ross_mg[d, t, g] = self.ross_mg[d, t, g+1]
                         if self.plnk_mg[d, t, g] == 1e10:
                             self.plnk_mg[d, t, g] = self.plnk_mg[d, t, g+1]
-    def toEosDict(self):
-        pass
+
+    def toEosDict(self, fill_eos=False):
+        names_dict_req_tops = {
+            'nion': 'idens',
+            'temp': 'temp',
+            'dens': 'dens',
+            'zbar': 'Zf_DT',
+            'z2bar': 'z2bar',
+            'ross_mg': 'opr_mg',
+            'plnk_mg': 'opp_mg',
+            'plnk_mg': 'emp_mg',
+            'plnk_int': 'opp_int',
+            'ross_int': 'opr_int',
+            'plnk_int': 'emp_int',
+            'Xnum': 'Xnum',
+            'Massfrac': 'Massfrac',
+            'Znum': 'Znum',
+            'Zsymb': 'Zsymb',
+            'MatID': 'MatID',
+            'Zmax': 'Zmax',
+            'Anum': 'Anum',
+            'Abar': 'Abar',
+            'grps': 'groups',
+            'Zsymb': 'Zsymb',
+            'Nm': 'ElemNum',
+        }
+        names_dict_mg = {
+            'ross_mg': 'opr_mg',
+            'plnk_mg': 'opp_mg',
+            'plnk_mg': 'emp_mg',
+            'grps': 'groups',
+        }
+        names_list_req_eos = ['Pi_DT', 'Pec_DT', 'Ui_DT', 'Uec_DT', 'Zf_DT']
+
+        eos_dict = {}
+
+        # Data in TOPS table
+        for tops_key, eos_key in sorted(names_dict_req_tops.items()):
+            eos_dict[eos_key] = getattr(self, tops_key)
+        if self.multigroup:
+            for tops_key, eos_key in sorted(names_dict_mg.items()):
+                eos_dict[eos_key] = getattr(self, tops_key)
+        eos_dict['temp'] = eos_dict['temp'] * 1e-3
+        eos_dict['groups'] = eos_dict['groups'] * 1e-3
+
+        # Fill zeros for EOS
+        if fill_eos:
+            for eos_key in names_list_req_eos:
+                eos_dict[eos_key] = np.zeros_like(eos_dict['Zf_DT'])
+
+        return eos_dict

--- a/opacplot2/opg_tops.py
+++ b/opacplot2/opg_tops.py
@@ -1,141 +1,237 @@
+from math import ceil
 import numpy as np
-from numbers import Number
+from os.path import splitext
+from io import StringIO
+import periodictable
+
+# Avogadros number
+NA = 6.0221415e+23
 
 
-class opg_tops():
-    def __init__(self, fname, epmax='auto', lowerceiling=False, usenear=False):
-        """_summary_
+def tops_html2text(filename):
+    """Convert TOPS opacity table in html format to text
+
+    Parameters
+    ----------
+    filename : str
+        filename of html file for TOPS table
+
+    Returns
+    -------
+    str
+        text of TOPS table
+    """
+
+    from bs4 import BeautifulSoup
+
+    with open(filename) as fp:
+        soup = BeautifulSoup(fp, 'html.parser')
+
+    code = soup.find_all('code')[0]
+    text = [' '.join(a.text.split('\xa0')).rstrip() + ' \n'
+                  for a in code.contents[0::2]]
+    text = (' '+''.join(text).lstrip()).rstrip()
+
+    return text
+
+class OpgTOPS():
+    def __init__(self, filename, ep_max='auto', handle_large_entry='no'):
+        """
+        Parse TOPS Opacities
 
         Parameters
         ----------
         fname : str
-            The name of the file to open.
-        epmax : str or float, optional
-            if epmax == 'log', then use logarithmic extrapolation
-            if epmax == 'linear', then use linear extrapolation
-        lowerceiling : bool, optional
-            _description_, by default False
-        usenear : bool, optional
-            _description_, by default False
+            Filename of the .tops or .html file
+        epmax : {'log', 'lin', 'auto'} or float, optional
+            The upper bound of photon energy (eV) in the last photon group, by
+            default 'auto'
+            - 'log': use logarithmic extrapolation to calculate `epmax`
+            - 'lin': use linear extrapolation to calculate `epmax`
+            - 'auto': automatically choose from {'log', 'lin'}
+        handle_large_entry : {'no', 'lower_ceiling', 'next_group'}
+            Choose how to handle group opacity entries with value 1e10, by
+            default 'no'
+            - 'no': do nothing
+            - 'lower_ceiling' : use the largest opacity value throughout the
+            table that is below 1e10
+            - 'next_group' : use the opacity value of the next photon group
+            at the same temperature-density point
         """
-        self.fname = fname
-        self.NT = 0
-        self.Nd = 0
-        self.Ng = 0
-        self.dens = []
-        self.temp = []
-        self.grps = []
-        self.ross = []
-        self.plnk = []
-        self.epmax = epmax
-        self.lowerceiling = lowerceiling
-        self.usenear = usenear
-        self.get_data(fname)
 
-    def get_data(self, fname):
+        self.filename = filename
+        if splitext(filename)[1] == '.html':
+            lines = StringIO(tops_html2text(filename)).readlines()
+        else:
+            with open(filename, 'r') as f:
+                lines = f.readlines()
 
-        fid = open(fname, 'r')
+        try:
+            assert isinstance(ep_max, float)
+        except AssertionError:
+            try:
+                assert ep_max in {'log', 'lin', 'auto'}
+            except AssertionError:
+                raise KeyError("epmax should be in {'log', 'lin', 'auto'} or "
+                               "float!")
+        self.ep_max = ep_max
 
-        line = fid.readline()
-        dats = [int(s) for s in line.split() if s.isdigit()]
-        self.NT = dats[0]
-        self.Nd = dats[1]
+        try:
+            assert handle_large_entry in \
+                {'no', 'lower_ceiling', 'use_next_group'}
+        except AssertionError:
+            raise KeyError("handle_large_entry shoule be in "
+                           "{'no', 'lower_ceiling', 'use_next_group'}")
+        self.handle_large_entry = handle_large_entry
 
-        # Read up to temp grid
-        for line in fid:
-            if line.split()[0] == 'Temperature':
-                break
+        dats = [int(s) for s in lines[0].split() if s.isdigit()]
+        self.NT, self.Nd, self.Nm = dats[0:3]
+
+        # Read elements and number fractions
+        for lid, line in enumerate(lines):
+            line_split = line.split()
+            if line_split[:10] == \
+                "No. Fraction Mass Fraction  At. No.  Chem. Sym.  Mat ID.".\
+                split():
+                lid_frac = lid
+                lid_temp = lid_frac + 1 + self.Nm
+                dataio = StringIO(''.join(lines[lid_frac+1:lid_temp]))
+                dats = np.loadtxt(dataio,
+                                  dtype={'names': ["Xnum", "Mfrac", "Znum",
+                                                   "Zsymb",  "MatID"],
+                                         'formats':['f8', 'f8', 'i4',
+                                                    'S2','i4']
+                                         }
+                                  )
+                dats.reshape(self.Nm)
+                self.Xnum = dats['Xnum']
+                self.Mfrac = dats['Mfrac']
+                self.Znum = dats['Znum']
+                self.Zsymb= dats['Zsymb']
+                self.MatID = dats['MatID']
+                self.Zmax = np.average(self.Znum, weights=self.Xnum)
+                self.Anum = np.array([periodictable.elements[Znum].mass \
+                                        for Znum in self.Znum])
+                self.Abar = np.average(self.Anum, weights=self.Xnum)
 
         # Read temperature grid
-        self.temp = np.zeros(self.NT)
-        i = 0
-        for line in fid:
-            lb = line.split()
-            if lb[0] == 'Density':
-                break
-            for t in lb:
-                self.temp[i] = float(t)
-                i += 1
-        assert i == self.NT
+        line_split = lines[lid_temp].split()
+        assert line_split[:5] == 'Temperature grid used the following'.split()
+        assert int(line_split[5]) == self.NT
+        lid_dens = lid_temp + 1 + int(np.ceil(self.NT/6))
+        self.temp = np.fromstring(' '.join(lines[lid_temp+1:lid_dens]), sep=' ')
+        self.temp.reshape(self.NT)
 
         # Read density grid
-        self.dens = np.zeros(self.Nd)
-        i = 0
-        for line in fid:
-            lb = line.split()
-            if lb[0] == 'Photon':
-                dats = [int(s) for s in line.split() if s.isdigit()]
-                self.Ng = 1 + dats[0]
-                break
-            for t in lb:
-                self.dens[i] = float(t)
-                i += 1
-        assert i == self.Nd
+        line_split = lines[lid_dens].split()
+        assert line_split[:5] == 'Density grid used the following'.split()
+        assert int(line_split[5]) == self.Nd
+        lid_grps = lid_dens + 1 + int(np.ceil(self.Nd/6))
+        self.dens = np.fromstring(' '.join(lines[lid_dens+1:lid_grps]), sep=' ')
+        self.dens.reshape(self.Nd)
 
         # Read photon grid
-        self.grps = np.zeros(self.Ng)
-        i = 0
-        for line in fid:
-            lb = line.split()
-            if lb[0] == 'Rosseland':
-                break
-            for t in lb:
-                self.grps[i] = float(t)
-                i += 1
-        assert i == self.Ng - 1
+        line_split = lines[lid_grps].split()
+        if line_split[0] == 'Photon':
+            self.Ng = int(line_split[5])
+            self.multigroup = True
+            lid_opac = lid_grps + 1 + int(np.ceil(self.Ng/6))
+            self.grps = np.fromstring(' '.join(lines[lid_grps+1:lid_opac]),
+                                     sep=' ')
+            self.grps.reshape(self.Ng)
+            self.grps = np.concatenate([self.grps, [np.inf]])
+            use_fit = 'no'
+            if isinstance(ep_max, float):
+                self.grps[self.Ng] = ep_max
+                use_fit = 'no'
+            elif ep_max == 'lin': use_fit = 'lin'
+            elif ep_max == 'log': use_fit = 'log'
+            elif ep_max == 'auto':
+                corr_log_fit = np.corrcoef(range(self.Ng-1),
+                                           np.log(self.grps[:self.Ng-1]))[0, 1]
+                corr_lin_fit = np.corrcoef(range(self.Ng-1),
+                                           self.grps[:self.Ng-1])[0, 1]
+                use_fit = ('log' if corr_log_fit > corr_lin_fit else 'lin')
+            if use_fit == 'log':
+                fit = np.polyfit(range(self.Ng), np.log(self.grps[:self.Ng]), 1)
+                self.grps[self.Ng] = np.exp(fit[1] + fit[0] * (self.Ng))
+            elif use_fit == 'lin':
+                fit = np.polyfit(range(self.Ng), self.grps[:self.Ng], 1)
+                self.grps[self.Ng] = fit[1] + fit[0] * (self.Ng)
+        elif line_split[0] == 'Rosseland':
+            self.multigroup = False
+            lid_opac = lid_grps
 
-        # Last group boundary not included in tops table, use epmax
-        if isinstance(self.epmax, Number):
-            self.grps[Ng-1] = self.epmax
-        elif self.epmax == 'auto':
-            corr_log = np.corrcoef(range(self.Ng-1),
-                                   np.log(self.grps[:self.Ng-1]))[0, 1]
-            corr_linear = np.corrcoef(range(self.Ng-1),
-                                      self.grps[:self.Ng-1])[0, 1]
-            if corr_log > corr_linear:
-                self.epmax = 'log'
-            else:
-                self.epmax = 'linear'
+        # Read gray opacity and free electron number moments
+        self.ross_int = np.zeros((self.NT, self.Nd))
+        self.plnk_int = np.zeros((self.NT, self.Nd))
+        self.zbar = np.zeros((self.NT, self.Nd))
+        self.z2bar = np.zeros((self.NT, self.Nd))
 
-        # Do logrithmic or linear extrapolation if requested
-        if self.epmax == 'log':
-            fit = np.polyfit(range(self.Ng-1),
-                             np.log(self.grps[:self.Ng-1]), 1)
-            self.grps[self.Ng-1] = np.exp(fit[1] + fit[0] * (self.Ng-1))
-        elif self.epmax == 'linear':
-            fit = np.polyfit(range(self.Ng-1), self.grps[:self.Ng-1], 1)
-            self.grps[self.Ng-1] = fit[1] + fit[0] * (self.Ng-1)
-        else:
-            raise ValueError("Invalid value for epmax, use float or one \
-string from 'auto', 'log', 'linear'")
+        for t in range(self.NT):
+            line_split = lines[lid_opac].split()
+            assert line_split[:7] == \
+                "Rosseland and Planck opacities and free electrons".split()
+            line_split = lines[lid_opac+1].split()
+            assert line_split[:11] == \
+                "Density Ross opa Planck opa No. Free Av Sq Free T=".split()
+            dataio = StringIO("".join(lines[lid_opac+2:lid_opac+2+self.Nd]))
+            dats = np.loadtxt(dataio)
+            dats.reshape((self.Nd, 5))
+            assert (self.dens == dats[:,0]).all()
+            self.ross_int[t] = dats[:,1]
+            self.plnk_int[t] = dats[:,2]
+            self.zbar[t] = dats[:,3]
+            self.z2bar[t] = dats[:,4]
+            lid_opac += 2 + self.Nd
 
-        # Skip to multigroup opacities
-        self.ross = np.zeros((self.Nd, self.NT, self.Ng-1))
-        self.plnk = np.zeros((self.Nd, self.NT, self.Ng-1))
-        for line in fid:
-            if line.split()[0] == 'Multigroup':
-                break
+        self.ross_int = self.ross_int.T
+        self.plnk_int = self.plnk_int.T
+        self.zbar = self.zbar.T
+        self.z2bar = self.z2bar.T
+
+        # Read multigroup opacity
+        if not self.multigroup: return
+        self.ross_mg = np.zeros((self.NT, self.Nd, self.Ng))
+        self.plnk_mg = np.zeros((self.NT, self.Nd, self.Ng))
+
+        line_split = lines[lid_opac].split()
+        assert line_split[:2] == 'Multigroup opacities'.split()
+        lid_opac += 1
+
         for t in range(self.NT):
             for d in range(self.Nd):
-                line = fid.readline()
-                assert line.split()[0] == 'Energy'
-                for g in range(self.Ng-1):
-                    line = fid.readline()
-                    lb = line.split()
-                    self.ross[d, t, g] = float(lb[1])
-                    self.plnk[d, t, g] = float(lb[2])
-        if self.lowerceiling:
-            ceilingvalue = self.ross[self.ross < 1e10].max()
-            self.ross[self.ross == 1e10] = ceilingvalue
-            ceilingvalue = self.plnk[self.plnk < 1e10].max()
-            self.plnk[self.plnk == 1e10] = ceilingvalue
-        if self.usenear:
-            for t in range(self.NT):
-                for d in range(self.Nd):
-                    for g in range(-2, -self.Ng, -1):
-                        if self.ross[d, t, g] == 1e10:
-                            self.ross[d, t, g] = self.ross[d, t, g+1]
-                        if self.plnk[d, t, g] == 1e10:
-                            self.plnk[d, t, g] = self.plnk[d, t, g+1]
+                line_split = lines[lid_opac].split()
+                assert line_split[:9] == \
+                    "Energy Ross mg Planck mg for T, density =".split()
+                assert self.temp[t] == float(line_split[9])
+                assert self.dens[d] == float(line_split[10])
+                dataio = StringIO("".join(lines[lid_opac+1:lid_opac+1+self.Ng]))
+                dats = np.loadtxt(dataio)
+                dats.reshape((self.Ng,3))
+                assert (self.grps[:self.Ng] == dats[:,0]).all()
+                self.ross_mg[t,d] = dats[:,1]
+                self.plnk_mg[t,d] = dats[:,2]
+                lid_opac += 1 + self.Ng
 
-        fid.close()
+        self.ross_mg = self.ross_mg.swapaxes(0, 1)
+        self.plnk_mg = self.plnk_mg.swapaxes(0, 1)
+
+        # Handle the entries with unphsically large value 1e10
+        if self.handle_large_entry == 'no': return
+        if self.handle_large_entry == 'lower_ceiling':
+            ceiling_value = self.ross_mg[self.ross_mg < 1e10].max()
+            self.ross_mg[self.ross_mg == 1e10] = ceiling_value
+            ceiling_value = self.plnk_mg[self.plnk_mg < 1e10].max()
+            self.plnk_mg[self.plnk_mg == 1e10] = ceiling_value
+            return
+        if self.handle_large_entry == 'use_next':
+            for d in range(self.Nd):
+                for t in range(self.NT):
+                    for g in range(Ng)[::-1]:
+                        if self.ross_mg[d, t, g] == 1e10:
+                            self.ross_mg[d, t, g] = self.ross_mg[d, t, g+1]
+                        if self.plnk_mg[d, t, g] == 1e10:
+                            self.plnk_mg[d, t, g] = self.plnk_mg[d, t, g+1]
+    def toEosDict(self):
+        pass

--- a/opacplot2/opg_tops.py
+++ b/opacplot2/opg_tops.py
@@ -274,7 +274,7 @@ class OpgTOPS():
             'plnk_mg': 'emp_mg',
             'grps': 'groups',
         }
-        names_list_req_eos = ['Pi_DT', 'Pec_DT', 'Ui_DT', 'Uec_DT', 'Zf_DT']
+        names_list_req_eos = ['Pi_DT', 'Pec_DT', 'Ui_DT', 'Uec_DT']
 
         eos_dict = {}
 

--- a/opacplot2/opg_tops.py
+++ b/opacplot2/opg_tops.py
@@ -284,8 +284,8 @@ class OpgTOPS():
         if self.multigroup:
             for tops_key, eos_key in sorted(names_dict_mg.items()):
                 eos_dict[eos_key] = getattr(self, tops_key)
-        eos_dict['temp'] = eos_dict['temp'] * 1e-3
-        eos_dict['groups'] = eos_dict['groups'] * 1e-3
+        eos_dict['temp'] = eos_dict['temp'] * 1e3
+        eos_dict['groups'] = eos_dict['groups'] * 1e3
 
         # Fill zeros for EOS
         if fill_eos:

--- a/opacplot2/opg_tops.py
+++ b/opacplot2/opg_tops.py
@@ -1,0 +1,141 @@
+import numpy as np
+from numbers import Number
+
+
+class opg_tops():
+    def __init__(self, fname, epmax='auto', lowerceiling=False, usenear=False):
+        """_summary_
+
+        Parameters
+        ----------
+        fname : str
+            The name of the file to open.
+        epmax : str or float, optional
+            if epmax == 'log', then use logarithmic extrapolation
+            if epmax == 'linear', then use linear extrapolation
+        lowerceiling : bool, optional
+            _description_, by default False
+        usenear : bool, optional
+            _description_, by default False
+        """
+        self.fname = fname
+        self.NT = 0
+        self.Nd = 0
+        self.Ng = 0
+        self.dens = []
+        self.temp = []
+        self.grps = []
+        self.ross = []
+        self.plnk = []
+        self.epmax = epmax
+        self.lowerceiling = lowerceiling
+        self.usenear = usenear
+        self.get_data(fname)
+
+    def get_data(self, fname):
+
+        fid = open(fname, 'r')
+
+        line = fid.readline()
+        dats = [int(s) for s in line.split() if s.isdigit()]
+        self.NT = dats[0]
+        self.Nd = dats[1]
+
+        # Read up to temp grid
+        for line in fid:
+            if line.split()[0] == 'Temperature':
+                break
+
+        # Read temperature grid
+        self.temp = np.zeros(self.NT)
+        i = 0
+        for line in fid:
+            lb = line.split()
+            if lb[0] == 'Density':
+                break
+            for t in lb:
+                self.temp[i] = float(t)
+                i += 1
+        assert i == self.NT
+
+        # Read density grid
+        self.dens = np.zeros(self.Nd)
+        i = 0
+        for line in fid:
+            lb = line.split()
+            if lb[0] == 'Photon':
+                dats = [int(s) for s in line.split() if s.isdigit()]
+                self.Ng = 1 + dats[0]
+                break
+            for t in lb:
+                self.dens[i] = float(t)
+                i += 1
+        assert i == self.Nd
+
+        # Read photon grid
+        self.grps = np.zeros(self.Ng)
+        i = 0
+        for line in fid:
+            lb = line.split()
+            if lb[0] == 'Rosseland':
+                break
+            for t in lb:
+                self.grps[i] = float(t)
+                i += 1
+        assert i == self.Ng - 1
+
+        # Last group boundary not included in tops table, use epmax
+        if isinstance(self.epmax, Number):
+            self.grps[Ng-1] = self.epmax
+        elif self.epmax == 'auto':
+            corr_log = np.corrcoef(range(self.Ng-1),
+                                   np.log(self.grps[:self.Ng-1]))[0, 1]
+            corr_linear = np.corrcoef(range(self.Ng-1),
+                                      self.grps[:self.Ng-1])[0, 1]
+            if corr_log > corr_linear:
+                self.epmax = 'log'
+            else:
+                self.epmax = 'linear'
+
+        # Do logrithmic or linear extrapolation if requested
+        if self.epmax == 'log':
+            fit = np.polyfit(range(self.Ng-1),
+                             np.log(self.grps[:self.Ng-1]), 1)
+            self.grps[self.Ng-1] = np.exp(fit[1] + fit[0] * (self.Ng-1))
+        elif self.epmax == 'linear':
+            fit = np.polyfit(range(self.Ng-1), self.grps[:self.Ng-1], 1)
+            self.grps[self.Ng-1] = fit[1] + fit[0] * (self.Ng-1)
+        else:
+            raise ValueError("Invalid value for epmax, use float or one \
+string from 'auto', 'log', 'linear'")
+
+        # Skip to multigroup opacities
+        self.ross = np.zeros((self.Nd, self.NT, self.Ng-1))
+        self.plnk = np.zeros((self.Nd, self.NT, self.Ng-1))
+        for line in fid:
+            if line.split()[0] == 'Multigroup':
+                break
+        for t in range(self.NT):
+            for d in range(self.Nd):
+                line = fid.readline()
+                assert line.split()[0] == 'Energy'
+                for g in range(self.Ng-1):
+                    line = fid.readline()
+                    lb = line.split()
+                    self.ross[d, t, g] = float(lb[1])
+                    self.plnk[d, t, g] = float(lb[2])
+        if self.lowerceiling:
+            ceilingvalue = self.ross[self.ross < 1e10].max()
+            self.ross[self.ross == 1e10] = ceilingvalue
+            ceilingvalue = self.plnk[self.plnk < 1e10].max()
+            self.plnk[self.plnk == 1e10] = ceilingvalue
+        if self.usenear:
+            for t in range(self.NT):
+                for d in range(self.Nd):
+                    for g in range(-2, -self.Ng, -1):
+                        if self.ross[d, t, g] == 1e10:
+                            self.ross[d, t, g] = self.ross[d, t, g+1]
+                        if self.plnk[d, t, g] == 1e10:
+                            self.plnk[d, t, g] = self.plnk[d, t, g+1]
+
+        fid.close()

--- a/opacplot2/scripts/opac_convert.py
+++ b/opacplot2/scripts/opac_convert.py
@@ -5,7 +5,7 @@ import os.path
 def get_input_data():
     # Available formats.
     avail_output_formats = ['ionmix']
-    avail_input_formats = ['propaceos', 'multi', 'sesame', 'sesame-qeos']
+    avail_input_formats = ['propaceos', 'multi', 'sesame', 'sesame-qeos', 'tops']
 
     # Creating the argument parser.
     parser = argparse.ArgumentParser(

--- a/opacplot2/scripts/opac_convert.py
+++ b/opacplot2/scripts/opac_convert.py
@@ -100,7 +100,10 @@ def read_format_ext(args, fn_in):
                 '.opz':'multi',
                 '.opr':'multi',
                 '.mexport':'sesame-qeos',
-                '.ses':'sesame'}
+                '.ses':'sesame',
+                '.html':'tops',
+                '.tops':'tops',
+                }
     # If the input file is compressed, choose the next extension.
     if os.path.splitext(fn_in)[1] == '.gz':
         _, ext = os.path.splitext(os.path.splitext(fn_in)[0])
@@ -140,7 +143,9 @@ class Formats_toEosDict(object):
         self.handle_dict = {'propaceos' : self.propaceos_toEosDict,
                             'multi' : self.multi_toEosDict,
                             'sesame' : self.sesame_toEosDict,
-                            'sesame-qeos' : self.sesame_qeos_toEosDict}
+                            'sesame-qeos' : self.sesame_qeos_toEosDict,
+                            'tops' : self.tops_toEosDict,
+                            }
 
     def propaceos_toEosDict(self):
         # If we are unable to find the correct library for opg_propaceos
@@ -203,6 +208,11 @@ class Formats_toEosDict(object):
         else:
             eos_dict = op.toEosDict(Znum=self.args.Znum, Xnum=self.args.Xfracs,
                                     qeos=True, log=self.args.log)
+        return eos_dict
+
+    def tops_toEosDict(self):
+        op = opp.OpgTOPS(self.path_in)
+        eos_dict = op.toEosDict(fill_eos=True)
         return eos_dict
 
 class EosDict_toIonmixFile(object):

--- a/opacplot2/scripts/tops_html2txt.py
+++ b/opacplot2/scripts/tops_html2txt.py
@@ -1,0 +1,53 @@
+'''Convert TOPS opacity table in html format to text file'''
+
+
+def tops_html2txt(filename):
+    """Convert TOPS opacity table in html format to text
+
+    Parameters
+    ----------
+    filename : str
+        filename of html file for TOPS table
+
+    Returns
+    -------
+    str
+        text of TOPS table
+    """
+
+    from bs4 import BeautifulSoup
+
+    with open(filename) as fp:
+        soup = BeautifulSoup(fp, 'html.parser')
+
+    code = soup.find_all('code')[0]
+    table_text = [' '.join(a.text.split('\xa0')).rstrip() + ' \n'
+                  for a in code.contents[0::2]]
+    table_text = (' '+''.join(table_text).lstrip()).rstrip()
+
+    return table_text
+
+
+def main():
+
+    import argparse
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('input', metavar='INPUT', type=str,
+                        help='input filename')
+    parser.add_argument('output', metavar='OUTPUT', type=str,
+                        help='input filename')
+    parser.add_argument('-p', action='store_true',
+                        help='print txt instead of save')
+    args = parser.parse_args()
+
+    table_text = tops_html2txt(args.input)
+
+    if args.p:
+        print(table_text)
+    else:
+        with open(args.output, 'w') as f:
+            f.write(table_text)
+
+
+if __name__ == '__main__':
+    main()

--- a/opacplot2/scripts/tops_html2txt.py
+++ b/opacplot2/scripts/tops_html2txt.py
@@ -1,53 +1,32 @@
 '''Convert TOPS opacity table in html format to text file'''
 
+from opacplot2 import tops_html2text
+from os.path import splitext
 
-def tops_html2txt(filename):
-    """Convert TOPS opacity table in html format to text
-
-    Parameters
-    ----------
-    filename : str
-        filename of html file for TOPS table
-
-    Returns
-    -------
-    str
-        text of TOPS table
-    """
-
-    from bs4 import BeautifulSoup
-
-    with open(filename) as fp:
-        soup = BeautifulSoup(fp, 'html.parser')
-
-    code = soup.find_all('code')[0]
-    table_text = [' '.join(a.text.split('\xa0')).rstrip() + ' \n'
-                  for a in code.contents[0::2]]
-    table_text = (' '+''.join(table_text).lstrip()).rstrip()
-
-    return table_text
-
-
-def main():
+def tops_html2txt():
 
     import argparse
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('input', metavar='INPUT', type=str,
                         help='input filename')
-    parser.add_argument('output', metavar='OUTPUT', type=str,
-                        help='input filename')
+    parser.add_argument('--output', '-o', metavar='OUTPUT', type=str,
+                        help='output filename')
     parser.add_argument('-p', action='store_true',
                         help='print txt instead of save')
     args = parser.parse_args()
 
-    table_text = tops_html2txt(args.input)
+    text = tops_html2text(args.input)
 
     if args.p:
-        print(table_text)
+        print(text)
     else:
-        with open(args.output, 'w') as f:
-            f.write(table_text)
+        if args.output is None:
+            fn_out = splitext(args.input)[1] + '.tops'
+        else:
+            fn_out = args.output
+        with open(fn_out, 'w') as f:
+            f.write(text)
 
 
 if __name__ == '__main__':
-    main()
+    tops_html2txt()

--- a/opacplot2/utils.py
+++ b/opacplot2/utils.py
@@ -33,13 +33,16 @@ except ModuleNotFoundError:
 
 @vectorize
 def planck_int(x):
+    if x <= 0.0: return 0.0
     x2 = x * x
     x3 = x2 * x
+    if x < 2.4988090297374141987:
+        p = x3*(1.0/3.0+x*(-1.0/8.0+x*(1.0/60.0+x2*(-1.0/5040.0+x2/272160.0))))
+        return p
     expmx = math.exp(-x)
-    p1 = 6.4939394022668291491 + x3*math.log(1.0-expmx) \
-        - 3.0*expmx*(2.0+2.0*x+x2) - 0.375*expmx*expmx*(1.0-2.0*x+2.0*x2)
-    p2 = x3*(1.0/3.0+x*(-1.0/8.0+x*(1/60.0+x2*(-1/5040.0+x2/272160.0))))
-    return min(p1, p2)
+    p = 6.4939394022668291491 + x3*math.log(1.0-expmx) \
+        - 3.0*expmx*(2.0+2.0*x+x2) - 0.375*expmx*expmx*(1.0+2.0*x+2.0*x2)
+    return p
 
 def randomize_ionmix(filename, outfilename):
     """Randomizes the data from an existing ionmix file and rewrites it

--- a/opacplot2/utils.py
+++ b/opacplot2/utils.py
@@ -24,6 +24,23 @@ import copy
 #               p.pi**4 * (u.eV/p.kb)**4 * (u.cm**2/u.g)).in_cgs())
 emis_const = 633391171028.5317
 
+try:
+    import numba
+    vectorize = numba.vectorize('float64(float64)', nopython=True)
+except ModuleNotFoundError:
+    Warning('numba not found, will use numpy.vectorize!')
+    vectorize = lambda f: np.vectorize(f, otypes=[float])
+
+@vectorize
+def planck_int(x):
+    x2 = x * x
+    x3 = x2 * x
+    expmx = math.exp(-x)
+    p1 = 6.4939394022668291491 + x3*math.log(1.0-expmx) \
+        - 3.0*expmx*(2.0+2.0*x+x2) - 0.375*expmx*expmx*(1.0-2.0*x+2.0*x2)
+    p2 = x3*(1.0/3.0+x*(-1.0/8.0+x*(1/60.0+x2*(-1/5040.0+x2/272160.0))))
+    return min(p1, p2)
+
 def randomize_ionmix(filename, outfilename):
     """Randomizes the data from an existing ionmix file and rewrites it
     to the outfile.

--- a/opacplot2/utils.py
+++ b/opacplot2/utils.py
@@ -27,8 +27,8 @@ emis_const = 633391171028.5317
 try:
     import numba
     vectorize = numba.vectorize('float64(float64)', nopython=True)
-except ModuleNotFoundError:
-    Warning('numba not found, will use numpy.vectorize!')
+except:
+    print('numba not found, will use numpy.vectorize!')
     vectorize = lambda f: np.vectorize(f, otypes=[float])
 
 @vectorize

--- a/opacplot2/utils.py
+++ b/opacplot2/utils.py
@@ -361,8 +361,8 @@ class fastInterpDT():
         if not ig.isdigit():
             raise KeyError
         ig = int(ig)
-        if key != f'{mainkey}_{ig}':
-            key = f'{mainkey}_{ig}'
+        if key != "{0}_{1}".format(mainkey,ig):
+            key = "{0}_{1}".format(mainkey,ig)
             if key in self._funcs.keys(): return self._funcs[key]
 
         if mainkey == 'alphaa':

--- a/opacplot2/utils.py
+++ b/opacplot2/utils.py
@@ -28,21 +28,300 @@ try:
     import numba
     vectorize = numba.vectorize('float64(float64)', nopython=True)
 except:
-    print('numba not found, will use numpy.vectorize!')
-    vectorize = lambda f: np.vectorize(f, otypes=[float])
+    try:
+        print('numba.vectorize not loaded, will use numpy.vectorize!')
+        def vectorize(f): return np.vectorize(f, otypes=[float])
+    except:
+        print('numpy.vectorize not loaded, will not use vectorization!')
+        def vectorize(f): return f
+
 
 @vectorize
-def planck_int(x):
-    if x <= 0.0: return 0.0
+def planck_int_521(x):
+    if x <= 0.0:
+        return 0.0
+    x2 = x * x
+    x3 = x2 * x
+    if x < 2.4986122463063526246:
+        p = 43867.0/107290978560589824000.0
+        p = -3617.0/202741834014720000.0+x2*p
+        p = 1.0/1270312243200.0+x2*p
+        p = -691.0/19615115520000.0+x2*p
+        p = 1.0/622702080.0+x2*p
+        p = -1.0/13305600.0+x2*p
+        p = 1.0/272160.0+x2*p
+        p = -1.0/5040.0+x2*p
+        p = 1.0/60.0+x2*p
+        p = -1.0/8.0+x*p
+        p = 1.0/3.0+x*p
+        p = x3*p
+        return p
+    expmx = math.exp(-x)
+    p = 6.4939394022668291491 + x3 * math.log(1.0-expmx)
+    p = p - 3.0*expmx*(2.0+2.0*x+x2)
+    expmnx = expmx*expmx
+    p = p - expmnx*(0.375+0.75*x+0.75*x2)
+    expmnx = expmnx*expmx
+    p = p - expmnx*((2.0/27.0)+(2.0/9.0)*x+(1.0/3.0)*x2)
+    expmnx = expmnx*expmx
+    p = p - expmnx*(0.0234375+0.09375*x+0.1875*x2)
+    expmnx = expmnx*expmx
+    p = p - expmnx*(0.0096+0.048*x+0.12*x2)
+    expmnx = expmnx*expmx
+    p = p - expmnx*((1.0/216.0)+(1.0/36.0)*x+(1.0/12.0)*x2)
+    return p
+
+
+@vectorize
+def planck_int_421(x):
+    if x <= 0.0:
+        return 0.0
+    x2 = x * x
+    x3 = x2 * x
+    if x < 2.6990184449053289902:
+        p = 43867.0/107290978560589824000.0
+        p = -3617.0/202741834014720000.0+x2*p
+        p = 1.0/1270312243200.0+x2*p
+        p = -691.0/19615115520000.0+x2*p
+        p = 1.0/622702080.0+x2*p
+        p = -1.0/13305600.0+x2*p
+        p = 1.0/272160.0+x2*p
+        p = -1.0/5040.0+x2*p
+        p = 1.0/60.0+x2*p
+        p = -1.0/8.0+x*p
+        p = 1.0/3.0+x*p
+        p = x3*p
+        return p
+    expmx = math.exp(-x)
+    p = 6.4939394022668291491 + x3 * math.log(1.0-expmx)
+    p = p - 3.0*expmx*(2.0+2.0*x+x2)
+    expmnx = expmx*expmx
+    p = p - expmnx*(0.375+0.75*x+0.75*x2)
+    expmnx = expmnx*expmx
+    p = p - expmnx*((2.0/27.0)+(2.0/9.0)*x+(1.0/3.0)*x2)
+    expmnx = expmnx*expmx
+    p = p - expmnx*(0.0234375+0.09375*x+0.1875*x2)
+    expmnx = expmnx*expmx
+    p = p - expmnx*(0.0096+0.048*x+0.12*x2)
+    return p
+
+
+@vectorize
+def planck_int_321(x):
+    if x <= 0.0:
+        return 0.0
+    x2 = x * x
+    x3 = x2 * x
+    if x < 2.9473262938307058478:
+        p = 43867.0/107290978560589824000.0
+        p = -3617.0/202741834014720000.0+x2*p
+        p = 1.0/1270312243200.0+x2*p
+        p = -691.0/19615115520000.0+x2*p
+        p = 1.0/622702080.0+x2*p
+        p = -1.0/13305600.0+x2*p
+        p = 1.0/272160.0+x2*p
+        p = -1.0/5040.0+x2*p
+        p = 1.0/60.0+x2*p
+        p = -1.0/8.0+x*p
+        p = 1.0/3.0+x*p
+        p = x3*p
+        return p
+    expmx = math.exp(-x)
+    p = 6.4939394022668291491 + x3 * math.log(1.0-expmx)
+    p = p - 3.0*expmx*(2.0+2.0*x+x2)
+    expmnx = expmx*expmx
+    p = p - expmnx*(0.375+0.75*x+0.75*x2)
+    expmnx = expmnx*expmx
+    p = p - expmnx*((2.0/27.0)+(2.0/9.0)*x+(1.0/3.0)*x2)
+    expmnx = expmnx*expmx
+    p = p - expmnx*(0.0234375+0.09375*x+0.1875*x2)
+    return p
+
+
+@vectorize
+def planck_int_221(x):
+    if x <= 0.0:
+        return 0.0
+    x2 = x * x
+    x3 = x2 * x
+    if x < 3.2665163511878142788:
+        p = 43867.0/107290978560589824000.0
+        p = -3617.0/202741834014720000.0+x2*p
+        p = 1.0/1270312243200.0+x2*p
+        p = -691.0/19615115520000.0+x2*p
+        p = 1.0/622702080.0+x2*p
+        p = -1.0/13305600.0+x2*p
+        p = 1.0/272160.0+x2*p
+        p = -1.0/5040.0+x2*p
+        p = 1.0/60.0+x2*p
+        p = -1.0/8.0+x*p
+        p = 1.0/3.0+x*p
+        p = x3*p
+        return p
+    expmx = math.exp(-x)
+    p = 6.4939394022668291491 + x3 * math.log(1.0-expmx)
+    p = p - 3.0*expmx*(2.0+2.0*x+x2)
+    expmnx = expmx*expmx
+    p = p - expmnx*(0.375+0.75*x+0.75*x2)
+    expmnx = expmnx*expmx
+    p = p - expmnx*((2.0/27.0)+(2.0/9.0)*x+(1.0/3.0)*x2)
+    return p
+
+
+@vectorize
+def planck_int_121(x):
+    if x <= 0.0:
+        return 0.0
+    x2 = x * x
+    x3 = x2 * x
+    if x < 3.6994817748082990076:
+        p = 43867.0/107290978560589824000.0
+        p = -3617.0/202741834014720000.0+x2*p
+        p = 1.0/1270312243200.0+x2*p
+        p = -691.0/19615115520000.0+x2*p
+        p = 1.0/622702080.0+x2*p
+        p = -1.0/13305600.0+x2*p
+        p = 1.0/272160.0+x2*p
+        p = -1.0/5040.0+x2*p
+        p = 1.0/60.0+x2*p
+        p = -1.0/8.0+x*p
+        p = 1.0/3.0+x*p
+        p = x3*p
+        return p
+    expmx = math.exp(-x)
+    p = 6.4939394022668291491 + x3 * math.log(1.0-expmx)
+    p = p - 3.0*expmx*(2.0+2.0*x+x2)
+    expmnx = expmx*expmx
+    p = p - expmnx*(0.375+0.75*x+0.75*x2)
+    return p
+
+
+@vectorize
+def planck_int_117(x):
+    if x <= 0.0:
+        return 0.0
+    x2 = x * x
+    x3 = x2 * x
+    if x < 3.4002776374783549206:
+        p = 1.0/1270312243200.0
+        p = -691.0/19615115520000.0+x2*p
+        p = 1.0/622702080.0+x2*p
+        p = -1.0/13305600.0+x2*p
+        p = 1.0/272160.0+x2*p
+        p = -1.0/5040.0+x2*p
+        p = 1.0/60.0+x2*p
+        p = -1.0/8.0+x*p
+        p = 1.0/3.0+x*p
+        p = x3*p
+        return p
+    expmx = math.exp(-x)
+    p = 6.4939394022668291491 + x3 * math.log(1.0-expmx)
+    p = p - 3.0*expmx*(2.0+2.0*x+x2)
+    expmnx = expmx*expmx
+    p = p - expmnx*(0.375+0.75*x+0.75*x2)
+    return p
+
+
+@vectorize
+def planck_int_113(x):
+    if x <= 0.0:
+        return 0.0
+    x2 = x * x
+    x3 = x2 * x
+    if x < 3.0162965117321811849:
+        p = 1.0/622702080.0
+        p = -1.0/13305600.0+x2*p
+        p = 1.0/272160.0+x2*p
+        p = -1.0/5040.0+x2*p
+        p = 1.0/60.0+x2*p
+        p = -1.0/8.0+x*p
+        p = 1.0/3.0+x*p
+        p = x3*p
+        return p
+    expmx = math.exp(-x)
+    p = 6.4939394022668291491 + x3 * math.log(1.0-expmx)
+    p = p - 3.0*expmx*(2.0+2.0*x+x2)
+    expmnx = expmx*expmx
+    p = p - expmnx*(0.375+0.75*x+0.75*x2)
+    return p
+
+
+@vectorize
+def planck_int_109(x):
+    if x <= 0.0:
+        return 0.0
     x2 = x * x
     x3 = x2 * x
     if x < 2.4988090297374141987:
-        p = x3*(1.0/3.0+x*(-1.0/8.0+x*(1.0/60.0+x2*(-1.0/5040.0+x2/272160.0))))
+        p = 1.0/272160.0
+        p = -1.0/5040.0+x2*p
+        p = 1.0/60.0+x2*p
+        p = -1.0/8.0+x*p
+        p = 1.0/3.0+x*p
+        p = x3*p
         return p
     expmx = math.exp(-x)
-    p = 6.4939394022668291491 + x3*math.log(1.0-expmx) \
-        - 3.0*expmx*(2.0+2.0*x+x2) - 0.375*expmx*expmx*(1.0+2.0*x+2.0*x2)
+    p = 6.4939394022668291491 + x3 * math.log(1.0-expmx)
+    p = p - 3.0*expmx*(2.0+2.0*x+x2)
+    expmnx = expmx*expmx
+    p = p - expmnx*(0.375+0.75*x+0.75*x2)
     return p
+
+
+@vectorize
+def planck_int_105(x):
+    if x <= 0.0:
+        return 0.0
+    x2 = x * x
+    x3 = x2 * x
+    if x < 1.7340547317779179179:
+        p = -1.0/5040.0
+        p = 1.0/60.0+x2*p
+        p = -1.0/8.0+x*p
+        p = 1.0/3.0+x*p
+        p = x3*p
+        return p
+    expmx = math.exp(-x)
+    p = 6.4939394022668291491 + x3 * math.log(1.0-expmx)
+    p = p - 3.0*expmx*(2.0+2.0*x+x2)
+    expmnx = expmx*expmx
+    p = p - expmnx*(0.375+0.75*x+0.75*x2)
+    return p
+
+
+_planck_int_tol_map = [
+    [1.0302715028868622245e-02, planck_int_105],
+    [8.5374180882613034532e-04, planck_int_109],
+    [1.7700322233243262879e-04, planck_int_113],
+    [5.6977042648474963933e-05, planck_int_117],
+    [2.3893770306629919069e-05, planck_int_121],
+    [1.7263725103039880405e-06, planck_int_221],
+    [1.9885715562521561098e-07, planck_int_321],
+    [3.1481596436276900432e-08, planck_int_421],
+    [6.2866968045513939899e-09, planck_int_521],
+]
+_planck_int = planck_int_109
+
+
+def planck_int_set_tolerance(tol, verbose=False):
+    global _planck_int
+    if tol < 0:
+        if verbose:
+            print('`tol` is negative, `planck_int` not changed')
+        return
+    for t, f in _planck_int_tol_map:
+        if tol >= t:
+            if verbose:
+                print('`planck_int` set to `{0}`'.format(f.__name__))
+            _planck_int = f
+            return
+    if verbose:
+        print('`tol` smaller than {0} is not available, '.format(t)
+              + '`planck_int` set to `{0}`'.format(f.__name__))
+    _planck_int = f
+
+
+def planck_int(x): return _planck_int(x)
 
 def randomize_ionmix(filename, outfilename):
     """Randomizes the data from an existing ionmix file and rewrites it

--- a/opacplot2/utils.py
+++ b/opacplot2/utils.py
@@ -32,8 +32,9 @@ except:
         print('numba.vectorize not loaded, will use numpy.vectorize!')
         def vectorize(f): return np.vectorize(f, otypes=[float])
     except:
-        print('numpy.vectorize not loaded, will not use vectorization!')
-        def vectorize(f): return f
+        print('numpy.vectorize not loaded, will use `list(map(f, x))`!')
+        def vectorize(f): return \
+            (lambda x: list(map(f, x)) if isinstance(x, list) else f(x))
 
 
 

--- a/opacplot2/utils.py
+++ b/opacplot2/utils.py
@@ -353,8 +353,8 @@ class fastInterpDT():
         if mainkey == 'emr':
             def func(x, y):
                 t = np.array(y)
-                xgl = self.eos_dict['groups'][ig-1] / t
-                xgr = self.eos_dict['groups'][ig] / t
+                xgl = self.eos_dict[self.g][ig-1] / t
+                xgr = self.eos_dict[self.g][ig]   / t
                 dp = planck_int(xgr) - planck_int(xgl)
                 opac = self.eval_linear(self.ucgrid,
                                         self.eos_dict['emp_mg'][:,:,ig-1],

--- a/opacplot2/utils.py
+++ b/opacplot2/utils.py
@@ -304,12 +304,17 @@ class fastInterpDT():
         Parameters
         ----------
         key : str
-            name of the variable for interpolaion.
+            Name of the variable for interpolaion. Valid values:
+            - key in `self.eos_dict`
+            - Absorption coefficient "alphaa_{ig}" (unit:1/cm) where `ig` is the
+            group index (from 1 to number of groups)
+            - Emission rate "emr_{ig}" (unit:erg/g/s) where `ig` is the group
+            index (from 1 to number of groups)
 
         Returns
         -------
         func : function
-            interpolation function
+            Interpolation function
         """
 
         if key in self._funcs.keys(): return self._funcs[key]

--- a/opacplot2/utils.py
+++ b/opacplot2/utils.py
@@ -10,7 +10,7 @@ from .constants import BC_BOUND, BC_EXTRAP_ZERO
 from .constants import INTERP_FUNC, INTERP_DFDD, INTERP_DFDT
 
 import os.path
-import opacplot2.opg_sesame
+import opacplot2
 
 import scipy as sp
 import scipy.interpolate
@@ -176,6 +176,9 @@ def interpDT(arr, dens, temps,
         return df_dt(f)
 
     raise ValueError("lookup must be INTERP_FUNC, INTERP_DFDD, or INTERP_DFDT")
+
+def fastInterpDT():
+    pass
 
 class EosMergeGrids(dict):
     """This class provides filtering capabilities for the EoS temperature and

--- a/opacplot2/utils.py
+++ b/opacplot2/utils.py
@@ -295,6 +295,15 @@ _planck_int = planck_int_213
 
 
 def planck_int_set_tolerance(tol, verbose=False):
+    """Set the orders used in `planck_int` by tolerance
+
+    Parameters
+    ----------
+    tol : float
+        tolerance (maximum allowed error)
+    verbose : bool, optional
+        print information, by default False
+    """
     global _planck_int
     if tol < 0:
         if verbose:
@@ -311,8 +320,24 @@ def planck_int_set_tolerance(tol, verbose=False):
               + '`planck_int` set to `{0}`'.format(f.__name__))
     _planck_int = f
 
+def planck_int(x):
+    """Compute planck integral
+       `$\int_{0}^{x}\frac{x^{\prime3}}{\exp(x^{\prime})-1}dx^{\prime}$`
+       using `m`-th order expansion as `exp(-x)->0` at large `x` and `n`-th
+       order expansion as `x->0` for small `x`. The ordres can be set by
+       `planck_int_set_tolerance`.
 
-def planck_int(x): return _planck_int(x)
+    Parameters
+    ----------
+    x : float, list or ndarray
+        Input value(s).
+
+    Returns
+    -------
+    float, list or numpy ndarray
+        Output value(s).
+    """
+    return _planck_int(x)
 
 def randomize_ionmix(filename, outfilename):
     """Randomizes the data from an existing ionmix file and rewrites it
@@ -482,7 +507,7 @@ class fastInterpDT():
         Parameters
         ----------
         eosopac : str or Eos/Opacity table in `opacplot2`
-            - First, if `eosopac` is str, `eosopac` is used as the filename of 
+            - First, if `eosopac` is str, `eosopac` is used as the filename of
             the table.
             - Otherwise, if `eosopac` is instance of class`opacplot2.OpacIonmix,
             class`opacplot2.OpgPropaceosAscii, class`opacplot2.OpgSesame,

--- a/opacplot2/utils.py
+++ b/opacplot2/utils.py
@@ -18,6 +18,12 @@ import scipy.misc
 
 import copy
 
+# from yt import physical_constants as p
+# from yt import units as u
+# emis_const = float((60.0 * p.stefan_boltzmann_constant /
+#               p.pi**4 * (u.eV/p.kb)**4 * (u.cm**2/u.g)).in_cgs())
+emis_const = 633391171028.5317
+
 def randomize_ionmix(filename, outfilename):
     """Randomizes the data from an existing ionmix file and rewrites it
     to the outfile.

--- a/opacplot2/utils.py
+++ b/opacplot2/utils.py
@@ -36,13 +36,15 @@ except:
         def vectorize(f): return f
 
 
+
+
 @vectorize
-def planck_int_521(x):
+def planck_int_621(x):
     if x <= 0.0:
         return 0.0
     x2 = x * x
     x3 = x2 * x
-    if x < 2.4986122463063526246:
+    if x < 2.6220995131254904878:
         p = 43867.0/107290978560589824000.0
         p = -3617.0/202741834014720000.0+x2*p
         p = 1.0/1270312243200.0+x2*p
@@ -57,18 +59,50 @@ def planck_int_521(x):
         p = x3*p
         return p
     expmx = math.exp(-x)
-    p = 6.4939394022668291491 + x3 * math.log(1.0-expmx)
-    p = p - 3.0*expmx*(2.0+2.0*x+x2)
+    p = 6.4939394022668291491 - expmx*(6.0+6.0*x+3.0*x2+x3)
     expmnx = expmx*expmx
-    p = p - expmnx*(0.375+0.75*x+0.75*x2)
+    p = p - expmnx*(0.375+0.75*x+0.75*x2+0.5*x3)
     expmnx = expmnx*expmx
-    p = p - expmnx*((2.0/27.0)+(2.0/9.0)*x+(1.0/3.0)*x2)
+    p = p - expmnx*((2.0/27.0)+(2.0/9.0)*x+(1.0/3.0)*x2+(1.0/3.0)*x3)
     expmnx = expmnx*expmx
-    p = p - expmnx*(0.0234375+0.09375*x+0.1875*x2)
+    p = p - expmnx*(0.0234375+0.09375*x+0.1875*x2+0.25*x3)
     expmnx = expmnx*expmx
-    p = p - expmnx*(0.0096+0.048*x+0.12*x2)
+    p = p - expmnx*(0.0096+0.048*x+0.12*x2+0.2*x3)
     expmnx = expmnx*expmx
-    p = p - expmnx*((1.0/216.0)+(1.0/36.0)*x+(1.0/12.0)*x2)
+    p = p - expmnx*((1.0/216.0)+(1.0/36.0)*x+(1.0/12.0)*x2+(1.0/6.0)*x3)
+    return p
+
+
+@vectorize
+def planck_int_521(x):
+    if x <= 0.0:
+        return 0.0
+    x2 = x * x
+    x3 = x2 * x
+    if x < 2.8319431973583671745:
+        p = 43867.0/107290978560589824000.0
+        p = -3617.0/202741834014720000.0+x2*p
+        p = 1.0/1270312243200.0+x2*p
+        p = -691.0/19615115520000.0+x2*p
+        p = 1.0/622702080.0+x2*p
+        p = -1.0/13305600.0+x2*p
+        p = 1.0/272160.0+x2*p
+        p = -1.0/5040.0+x2*p
+        p = 1.0/60.0+x2*p
+        p = -1.0/8.0+x*p
+        p = 1.0/3.0+x*p
+        p = x3*p
+        return p
+    expmx = math.exp(-x)
+    p = 6.4939394022668291491 - expmx*(6.0+6.0*x+3.0*x2+x3)
+    expmnx = expmx*expmx
+    p = p - expmnx*(0.375+0.75*x+0.75*x2+0.5*x3)
+    expmnx = expmnx*expmx
+    p = p - expmnx*((2.0/27.0)+(2.0/9.0)*x+(1.0/3.0)*x2+(1.0/3.0)*x3)
+    expmnx = expmnx*expmx
+    p = p - expmnx*(0.0234375+0.09375*x+0.1875*x2+0.25*x3)
+    expmnx = expmnx*expmx
+    p = p - expmnx*(0.0096+0.048*x+0.12*x2+0.2*x3)
     return p
 
 
@@ -78,7 +112,7 @@ def planck_int_421(x):
         return 0.0
     x2 = x * x
     x3 = x2 * x
-    if x < 2.6990184449053289902:
+    if x < 3.0912856367280557733:
         p = 43867.0/107290978560589824000.0
         p = -3617.0/202741834014720000.0+x2*p
         p = 1.0/1270312243200.0+x2*p
@@ -93,16 +127,13 @@ def planck_int_421(x):
         p = x3*p
         return p
     expmx = math.exp(-x)
-    p = 6.4939394022668291491 + x3 * math.log(1.0-expmx)
-    p = p - 3.0*expmx*(2.0+2.0*x+x2)
+    p = 6.4939394022668291491 - expmx*(6.0+6.0*x+3.0*x2+x3)
     expmnx = expmx*expmx
-    p = p - expmnx*(0.375+0.75*x+0.75*x2)
+    p = p - expmnx*(0.375+0.75*x+0.75*x2+0.5*x3)
     expmnx = expmnx*expmx
-    p = p - expmnx*((2.0/27.0)+(2.0/9.0)*x+(1.0/3.0)*x2)
+    p = p - expmnx*((2.0/27.0)+(2.0/9.0)*x+(1.0/3.0)*x2+(1.0/3.0)*x3)
     expmnx = expmnx*expmx
-    p = p - expmnx*(0.0234375+0.09375*x+0.1875*x2)
-    expmnx = expmnx*expmx
-    p = p - expmnx*(0.0096+0.048*x+0.12*x2)
+    p = p - expmnx*(0.0234375+0.09375*x+0.1875*x2+0.25*x3)
     return p
 
 
@@ -112,7 +143,7 @@ def planck_int_321(x):
         return 0.0
     x2 = x * x
     x3 = x2 * x
-    if x < 2.9473262938307058478:
+    if x < 3.4233592106975994941:
         p = 43867.0/107290978560589824000.0
         p = -3617.0/202741834014720000.0+x2*p
         p = 1.0/1270312243200.0+x2*p
@@ -127,14 +158,11 @@ def planck_int_321(x):
         p = x3*p
         return p
     expmx = math.exp(-x)
-    p = 6.4939394022668291491 + x3 * math.log(1.0-expmx)
-    p = p - 3.0*expmx*(2.0+2.0*x+x2)
+    p = 6.4939394022668291491 - expmx*(6.0+6.0*x+3.0*x2+x3)
     expmnx = expmx*expmx
-    p = p - expmnx*(0.375+0.75*x+0.75*x2)
+    p = p - expmnx*(0.375+0.75*x+0.75*x2+0.5*x3)
     expmnx = expmnx*expmx
-    p = p - expmnx*((2.0/27.0)+(2.0/9.0)*x+(1.0/3.0)*x2)
-    expmnx = expmnx*expmx
-    p = p - expmnx*(0.0234375+0.09375*x+0.1875*x2)
+    p = p - expmnx*((2.0/27.0)+(2.0/9.0)*x+(1.0/3.0)*x2+(1.0/3.0)*x3)
     return p
 
 
@@ -144,7 +172,7 @@ def planck_int_221(x):
         return 0.0
     x2 = x * x
     x3 = x2 * x
-    if x < 3.2665163511878142788:
+    if x < 3.8709108458308740467:
         p = 43867.0/107290978560589824000.0
         p = -3617.0/202741834014720000.0+x2*p
         p = 1.0/1270312243200.0+x2*p
@@ -159,50 +187,18 @@ def planck_int_221(x):
         p = x3*p
         return p
     expmx = math.exp(-x)
-    p = 6.4939394022668291491 + x3 * math.log(1.0-expmx)
-    p = p - 3.0*expmx*(2.0+2.0*x+x2)
-    expmnx = expmx*expmx
-    p = p - expmnx*(0.375+0.75*x+0.75*x2)
-    expmnx = expmnx*expmx
-    p = p - expmnx*((2.0/27.0)+(2.0/9.0)*x+(1.0/3.0)*x2)
+    p = 6.4939394022668291491 - expmx*(6.0+6.0*x+3.0*x2+x3)
+    p = p - expmx*expmx*(0.375+0.75*x+0.75*x2+0.5*x3)
     return p
 
 
 @vectorize
-def planck_int_121(x):
+def planck_int_217(x):
     if x <= 0.0:
         return 0.0
     x2 = x * x
     x3 = x2 * x
-    if x < 3.6994817748082990076:
-        p = 43867.0/107290978560589824000.0
-        p = -3617.0/202741834014720000.0+x2*p
-        p = 1.0/1270312243200.0+x2*p
-        p = -691.0/19615115520000.0+x2*p
-        p = 1.0/622702080.0+x2*p
-        p = -1.0/13305600.0+x2*p
-        p = 1.0/272160.0+x2*p
-        p = -1.0/5040.0+x2*p
-        p = 1.0/60.0+x2*p
-        p = -1.0/8.0+x*p
-        p = 1.0/3.0+x*p
-        p = x3*p
-        return p
-    expmx = math.exp(-x)
-    p = 6.4939394022668291491 + x3 * math.log(1.0-expmx)
-    p = p - 3.0*expmx*(2.0+2.0*x+x2)
-    expmnx = expmx*expmx
-    p = p - expmnx*(0.375+0.75*x+0.75*x2)
-    return p
-
-
-@vectorize
-def planck_int_117(x):
-    if x <= 0.0:
-        return 0.0
-    x2 = x * x
-    x3 = x2 * x
-    if x < 3.4002776374783549206:
+    if x < 3.5772328849933323604:
         p = 1.0/1270312243200.0
         p = -691.0/19615115520000.0+x2*p
         p = 1.0/622702080.0+x2*p
@@ -215,20 +211,18 @@ def planck_int_117(x):
         p = x3*p
         return p
     expmx = math.exp(-x)
-    p = 6.4939394022668291491 + x3 * math.log(1.0-expmx)
-    p = p - 3.0*expmx*(2.0+2.0*x+x2)
-    expmnx = expmx*expmx
-    p = p - expmnx*(0.375+0.75*x+0.75*x2)
+    p = 6.4939394022668291491 - expmx*(6.0+6.0*x+3.0*x2+x3)
+    p = p - expmx*expmx*(0.375+0.75*x+0.75*x2+0.5*x3)
     return p
 
 
 @vectorize
-def planck_int_113(x):
+def planck_int_213(x):
     if x <= 0.0:
         return 0.0
     x2 = x * x
     x3 = x2 * x
-    if x < 3.0162965117321811849:
+    if x < 3.1958913758529258675:
         p = 1.0/622702080.0
         p = -1.0/13305600.0+x2*p
         p = 1.0/272160.0+x2*p
@@ -239,20 +233,19 @@ def planck_int_113(x):
         p = x3*p
         return p
     expmx = math.exp(-x)
-    p = 6.4939394022668291491 + x3 * math.log(1.0-expmx)
-    p = p - 3.0*expmx*(2.0+2.0*x+x2)
-    expmnx = expmx*expmx
-    p = p - expmnx*(0.375+0.75*x+0.75*x2)
+    p = 6.4939394022668291491
+    p = p - expmx*(6.0+6.0*x+3.0*x2+x3)
+    p = p - expmx*expmx*(0.375+0.75*x+0.75*x2+0.5*x3)
     return p
 
 
 @vectorize
-def planck_int_109(x):
+def planck_int_209(x):
     if x <= 0.0:
         return 0.0
     x2 = x * x
     x3 = x2 * x
-    if x < 2.4988090297374141987:
+    if x < 2.6732813723804727115:
         p = 1.0/272160.0
         p = -1.0/5040.0+x2*p
         p = 1.0/60.0+x2*p
@@ -261,46 +254,43 @@ def planck_int_109(x):
         p = x3*p
         return p
     expmx = math.exp(-x)
-    p = 6.4939394022668291491 + x3 * math.log(1.0-expmx)
-    p = p - 3.0*expmx*(2.0+2.0*x+x2)
-    expmnx = expmx*expmx
-    p = p - expmnx*(0.375+0.75*x+0.75*x2)
+    p = 6.4939394022668291491
+    p = p - expmx*(6.0+6.0*x+3.0*x2+x3)
+    p = p - expmx*expmx*(0.375+0.75*x+0.75*x2+0.5*x3)
     return p
 
 
 @vectorize
-def planck_int_105(x):
+def planck_int_205(x):
     if x <= 0.0:
         return 0.0
     x2 = x * x
     x3 = x2 * x
-    if x < 1.7340547317779179179:
-        p = -1.0/5040.0
-        p = 1.0/60.0+x2*p
+    if x < 1.8785904766714333082:
+        p = 1.0/60.0
         p = -1.0/8.0+x*p
         p = 1.0/3.0+x*p
         p = x3*p
         return p
     expmx = math.exp(-x)
-    p = 6.4939394022668291491 + x3 * math.log(1.0-expmx)
-    p = p - 3.0*expmx*(2.0+2.0*x+x2)
-    expmnx = expmx*expmx
-    p = p - expmnx*(0.375+0.75*x+0.75*x2)
+    p = 6.4939394022668291491
+    p = p - expmx*(6.0+6.0*x+3.0*x2+x3)
+    p = p - expmx*expmx*(0.375+0.75*x+0.75*x2+0.5*x3)
     return p
 
 
 _planck_int_tol_map = [
-    [1.0302715028868622245e-02, planck_int_105],
-    [8.5374180882613034532e-04, planck_int_109],
-    [1.7700322233243262879e-04, planck_int_113],
-    [5.6977042648474963933e-05, planck_int_117],
-    [2.3893770306629919069e-05, planck_int_121],
-    [1.7263725103039880405e-06, planck_int_221],
-    [1.9885715562521561098e-07, planck_int_321],
-    [3.1481596436276900432e-08, planck_int_421],
-    [6.2866968045513939899e-09, planck_int_521],
+    [1.4970167008036724492e-02, planck_int_205],
+    [1.5564096579167360457e-03, planck_int_209],
+    [3.7610575515626060127e-04, planck_int_213],
+    [1.3579560624114267097e-04, planck_int_217],
+    [6.2367008414830821880e-05, planck_int_221],
+    [4.6393333440372567663e-06, planck_int_321],
+    [5.4123517973399470964e-07, planck_int_421],
+    [8.6098034553907039518e-08, planck_int_521],
+    [1.7204616971946109889e-08, planck_int_621],
 ]
-_planck_int = planck_int_109
+_planck_int = planck_int_213
 
 
 def planck_int_set_tolerance(tol, verbose=False):

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,8 @@ if __name__ == "__main__":
           entry_points = {
                     'console_scripts': ['opac-convert = opacplot2.scripts.opac_convert:convert_tables',
                                         'opac-error = opacplot2.scripts.opac_error:check_error',
-                                        'sesame-extract = opacplot2.scripts.sesame_extract:extract_tables'
+                                        'sesame-extract = opacplot2.scripts.sesame_extract:extract_tables',
+                                        'tops_html2txt = opacplot2.scripts.tops_html2txt:tops_html2txt',
                                         ],
                         }
           )


### PR DESCRIPTION
Implemented some new features

- Converter for TOPS table (https://aphysics2.lanl.gov/apps) in saved `.html` file to text (`tops_html2text`) or `.txt` file (script `tops_html2txt`)
- Reader for TOPS table (class:`OpgTOPS`) and converter to eosdict (`OpgTOPS.toEosDict`)
- TOPS to IONMIX converter in script `opac_convert`
- Compute planck integral in `utils.planck_int` by using `m`-th order expansion as `exp(-x)->0` at large `x` and `n`-th order expansion as `x->0` for small `x`. The ordres can be set by `utils.planck_int_set_tolerance`.
- Fast interplation `utils.fastInterpDT` by using `interpolation` package
- In `utils.fastInterpDT`, use keys `"alphaa_{ig}"` or `"emr_{ig}"` to access the interpolation of absorption coefficient or emission rate, respectively
